### PR TITLE
HTTP proxy settings

### DIFF
--- a/lib/couchdb.js
+++ b/lib/couchdb.js
@@ -178,14 +178,34 @@ CouchDB.prototype.client = function (method, path, data, callback) {
     }
 
     var proto = (this.instance.protocol === 'https:') ? https: http;
-
-    var request = proto.request({
+    var proxy = process.env[ "HTTP_PROXY" ] || process.env[ "http_proxy" ];
+    var params = {
         host: this.instance.hostname,
         port: this.instance.port,
         method: method,
         path: path,
         headers: headers
-    });
+    };
+    
+    if ( proxy ) {
+        var proxyUrl = url.parse( proxy );
+        params.headers = {
+            Host: params.host,
+            Port: params.port
+        };
+        params.host = proxyUrl.hostname;
+        params.port = proxyUrl.port;
+        
+        logger.info( "proxy", proxyUrl.hostname + ":" + proxyUrl.port );
+        
+        if ( proxyUrl.auth !== undefined ) {
+            params.headers[ "Proxy-Authorization" ] = "Basic " + new Buffer(
+                decodeURIComponent( proxyUrl.auth )
+            ).toString('base64');
+        }
+    }
+
+    var request = proto.request( params );
 
     logger.debug('request', method + ' ' + path);
     logger.debug('request headers', headers);

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -546,7 +546,8 @@ exports.fetch = function (name, version, repos, callback) {
 exports.download = function (file, callback) {
     var target = exports.TMP_DIR + '/' + path.basename(file);
     var urlinfo = url.parse(file);
-
+    var proxy = process.env[ "HTTP_PROXY" ] || process.env[ "http_proxy" ];
+    
     var _cb = callback;
     callback = function (err) {
         var that = this;
@@ -576,7 +577,8 @@ exports.download = function (file, callback) {
         var req = request({
             uri: urlinfo,
             method: 'GET',
-            headers: headers
+            headers: headers,
+            proxy: proxy
         }, function() {
             callback(null, target);
         } );


### PR DESCRIPTION
I had trouble getting Jam to install packages through my work Mac today - we're behind a proxy - bombing out with:

Error: Error: getaddrinfo ENOENT
    at errnoException (dns.js:31:11)
    at Object.onanswer [as oncomplete](dns.js:140:16)

So here's the fix I used, using the HTTP_PROXY environment variable; feel free to include it if you feel it's useful.

Rich
