### PR TITLE
-d {dir} wasn't propagated through correctly

### DIFF
--- a/lib/commands/compile.js
+++ b/lib/commands/compile.js
@@ -142,7 +142,7 @@ exports.compile = function (settings, opt, callback) {
             );
         }
         else {
-            var impl = path.relative(
+            impl = path.relative(
                 source,
                 path.resolve(__dirname, '../../node_modules/requirejs/require.js')
             );
@@ -153,7 +153,7 @@ exports.compile = function (settings, opt, callback) {
             includes = opt.includes;
         }
         else {
-            includes = ['jam/require.config.js'].concat(opt.includes);
+            includes = [path.join(opt.pkgdir, 'require.config.js')].concat(opt.includes);
         }
 
         var config = {


### PR DESCRIPTION
When running: `jam compile -d {dir} <target>`, it was failing to find `jam/require.config.js` instead of `{dir}/require.config.js`
