### PR TITLE
Excluded .svn directory from 'jam ls' consideration

### DIFF
--- a/lib/commands/clean.js
+++ b/lib/commands/clean.js
@@ -177,7 +177,7 @@ exports.unusedDirsTree = function (packages, opt, callback) {
 
 
 /**
- * List directories within a directory. Filters out regular files etc.
+ * List directories within a directory. Filters out regular files and subversion .svn directory (if any).
  *
  * @param {String} dir
  * @param {Function} callback
@@ -196,7 +196,7 @@ exports.listDirs = function (dir, callback) {
                 return callback(err);
             }
             var dirs = _.compact(results.map(function (d) {
-                return d.dir ? d.path: null;
+                return d.dir && d.path.substr(-5) !== '/.svn' ? d.path: null;
             }));
             return callback(null, dirs);
         });


### PR DESCRIPTION
Hello Caolan,

'jam ls' fails when used inside subversion controlled repository. 

```
Error: ENOENT, open '<some_path>/thirdparty/.svn/package.json'
Error: TypeError: Cannot read property 'length' of undefined
```

It would be really great if you could merge in provided fix.

Thank you.
