### PR TITLE
Fixes #63 - Split paths using the system path separator

### DIFF
--- a/lib/project.js
+++ b/lib/project.js
@@ -147,7 +147,7 @@ exports.updateRequireConfig = function (package_dir, baseurl, callback) {
     var shims = {};
 
     var basedir = baseurl ? path.relative(baseurl, package_dir): package_dir;
-    var dir = basedir.split('/').map(encodeURIComponent).join('/');
+    var dir = basedir.split(path.sep).map(encodeURIComponent).join('/');
 
     exports.getAllPackages(package_dir, function (err, pkgs) {
         if (err) {


### PR DESCRIPTION
This is a pull request, taken from @DragonDTG's repository, to help get it merged into the main product.  This issue is a blocker for using on Windows.
