### PR TITLE
Added support for JAMRC environmental variable

### DIFF
--- a/lib/jamrc.js
+++ b/lib/jamrc.js
@@ -28,6 +28,9 @@ exports.PATHS = [
     env.home + '/.jamrc'
 ];
 
+if(process.platform !== 'win32' && process.env.JAMRC !== undefined) {
+    exports.PATHS = [process.env.JAMRC];
+}
 
 /**
  * The defaults jamrc settings


### PR DESCRIPTION
Added support for JAMRC environmental variable, that overrides the location of the .jamrc file.

Scenario:

I have two apps with a number of deps specified in their package.json.
Each of these two apps depends on a specific repository, so I would like they don't use a shared ~/.jamrc, however I don't want to create a specific user for each of these two apps.

`jam install` and `jam upgrade` have support for specifying the repository on the command line, but only one repository.

I would like to be able to run:

```sh
JAMRC=.jamrc jam upgrade
```

in each app and make sure they use the correct repository list.


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/caolan/jam/82)
<!-- Reviewable:end -->
