### PR TITLE
Fully qualified domain when requesting packages through a proxy.

### DIFF
--- a/lib/couchdb.js
+++ b/lib/couchdb.js
@@ -12,6 +12,7 @@ var url = require('url'),
     querystring = require('querystring'),
     _ = require('underscore');
 
+var BASE_REPO_PATH = 'http://jamjs.org/'
 
 var STATUS_MSGS = {
     400: '400: Bad Request',
@@ -183,7 +184,7 @@ CouchDB.prototype.client = function (method, path, data, callback) {
         host: this.instance.hostname,
         port: this.instance.port,
         method: method,
-        path: path,
+        path: url.resolve(BASE_REPO_PATH, path),
         headers: headers
     };
 


### PR DESCRIPTION
Added base repository URL to path when requesting packages through proxies.  Proxy servers we have used require a fully qualified domain name for the resource you are requesting.
