### PR TITLE
Fully qualified domain when requesting packages through a proxy.

### DIFF
--- a/lib/couchdb.js
+++ b/lib/couchdb.js
@@ -12,8 +12,6 @@ var url = require('url'),
     querystring = require('querystring'),
     _ = require('underscore');
 
-var BASE_REPO_PATH = 'http://jamjs.org/'
-
 var STATUS_MSGS = {
     400: '400: Bad Request',
     401: '401: Unauthorized',
@@ -184,7 +182,7 @@ CouchDB.prototype.client = function (method, path, data, callback) {
         host: this.instance.hostname,
         port: this.instance.port,
         method: method,
-        path: url.resolve(BASE_REPO_PATH, path),
+        path: proxy ? url.resolve(this.instance.href, path) : path,
         headers: headers
     };
 


### PR DESCRIPTION
Amended to ensure custom repositories from .jamrc configurations are catered for.  Should only need to do this when requesting through a proxy (which this commit does) as they require validation of the request.
