### PR TITLE
Use the override the package.name with the jam.name if provided.

### DIFF
--- a/lib/project.js
+++ b/lib/project.js
@@ -173,6 +173,9 @@ exports.updateRequireConfig = function (package_dir, baseurl, callback) {
             if (main) {
                 val.main = main;
             }
+            if (cfg.jam && cfg.jam.name) {
+                val.name = cfg.jam.name;
+            }
             packages.push(val);
             if (cfg.shim) {
                 shims[cfg.name] = cfg.shim;

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -11,6 +11,11 @@ exports.load = async.memoize(function (dir, callback) {
             callback(err);
         }
         try {
+            // if there is a jam.name we must override the
+            // package name early.
+            if (settings.jam && settings.jam.name) {
+                settings.name = settings.jam.name;
+            }
             exports.validate(settings, settings_file);
         }
         catch (e) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jamjs",
-    "version": "0.2.11",
+    "version": "0.2.12",
     "description": "",
     "maintainers": [
         {"name": "Caolan McMahon", "web": "https://github.com/caolan"}


### PR DESCRIPTION
This allows the jam package name to be different than the original
package name. Needed when converting packages over from other package
managers, and for packages with a "something.js" name.

For issue #98
