### PR TITLE
Allow for absolute paths for baseUrl

### DIFF
--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -21,7 +21,8 @@ var semver = require('semver'),
     clean = require('./clean'),
     async = require('async'),
     path = require('path'),
-    fs = require('fs');
+    fs = require('fs'),
+    url = require('url');
 
 
 var pathExists = fs.exists || path.exists;
@@ -117,6 +118,8 @@ exports.run = function (settings, args) {
 
 
 exports.extendOptions = function (proj_dir, settings, cfg, opt) {
+    var baseUrl;
+
     if (!opt.target_dir) {
         if (cfg.jam && cfg.jam.packageDir) {
             opt.target_dir = path.resolve(proj_dir, cfg.jam.packageDir);
@@ -126,11 +129,13 @@ exports.extendOptions = function (proj_dir, settings, cfg, opt) {
         }
     }
     if (!opt.baseurl) {
-        if (cfg.jam && cfg.jam.baseUrl) {
-            opt.baseurl = path.resolve(proj_dir, cfg.jam.baseUrl);
-        }
-        else {
-            opt.baseurl = path.resolve(proj_dir, settings.baseUrl);
+        baseUrl = cfg.jam && cfg.jam.baseUrl || settings.baseUrl;
+
+        // if baseUrl is absolute, pass it directly
+        if (baseUrl && (baseUrl.indexOf('/') === 0 || url.parse(baseUrl).protocol)) {
+            opt.baseurl = baseUrl;
+        } else {
+            opt.baseurl = path.resolve(proj_dir, baseUrl);
         }
     }
     return opt;

--- a/lib/project.js
+++ b/lib/project.js
@@ -6,7 +6,6 @@ var utils = require('./utils'),
     ncp = require('ncp').ncp,
     fs = require('fs');
 
-
 var pathExists = fs.exists || path.exists;
 
 
@@ -146,11 +145,23 @@ exports.getAllPackages = function (dir, callback) {
 };
 
 exports.updateRequireConfig = function (package_dir, baseurl, callback) {
-    var packages = [];
-    var shims = {};
+    var packages = [],
+        shims = {},
+        basedir,
+        root;
 
-    var basedir = baseurl ? path.relative(baseurl, package_dir): package_dir;
-    var dir = basedir.split(path.sep).map(encodeURIComponent).join('/');
+    if (baseurl) {
+        // if the baseurl doesn't exist it's almost certainly intended as an absolute path
+        // TODO: use param instead to handle edge cases more robust
+        if (baseurl === '/' || !fs.existsSync(baseurl)) {
+            root = baseurl;
+        } else {
+            basedir = path.relative(baseurl, package_dir);
+            root = basedir.split(path.sep).map(encodeURIComponent).join('/');
+        }
+    } else {
+        root = package_dir.split(path.sep).map(encodeURIComponent).join('/');
+    }
 
     exports.getAllPackages(package_dir, function (err, pkgs) {
         if (err) {
@@ -161,7 +172,7 @@ exports.updateRequireConfig = function (package_dir, baseurl, callback) {
             var cfg = pkg.cfg;
             var val = {
                 name: cfg.name,
-                location: dir + '/' + encodeURIComponent(pkg.dir)
+                location: root + '/' + encodeURIComponent(pkg.dir)
             };
             var main = cfg.main;
             if (cfg.browser && cfg.browser.main) {


### PR DESCRIPTION
Issues #84 & #85 (and perhaps #45) relate to the need for absolute
paths for `baseUrl`.

This allows serving the same script references from the url `/foo` as
well as `/foo/:id`.

The test in `project.js` for absolute-ness could be more robust, but 
will serve for most cases, with a given value for "most".
