### PR TITLE
Allow defining more packages in the jam section.

### DIFF
--- a/lib/project.js
+++ b/lib/project.js
@@ -183,6 +183,21 @@ exports.updateRequireConfig = function (package_dir, baseurl, callback) {
             if (cfg.jam && cfg.jam.shim) {
                 shims[cfg.name] = cfg.jam.shim;
             }
+            if (cfg.jam && cfg.jam.extra_packages) {
+                var extra_packages = Object.keys(cfg.jam.extra_packages);
+                extra_packages.forEach(function(extra_pkg){
+                    var extra_val  = {
+                        name: extra_pkg,
+                        location: dir + '/' + encodeURIComponent(pkg.dir),
+                        main: cfg.jam.extra_packages[extra_pkg].main,
+                        local: true
+                    }
+                    packages.push(extra_val);
+                    if (extra_pkg.shim) {
+                        shims[extra_pkg.name] = extra_pkg.name;
+                    }
+                });
+            }
         });
 
         utils.getJamVersion(function (err, version) {


### PR DESCRIPTION
Work for Issue #99.

This helps porting over existing projects so that you don't have to
create a jam package for all the dependencies that are already in the
source of the current project.
