### PR TITLE
added shim config to compile command

### DIFF
--- a/lib/commands/compile.js
+++ b/lib/commands/compile.js
@@ -122,7 +122,8 @@ exports.run = function (settings, _args, commands) {
             wrap: a.options.wrap,
             optimize: 'uglify',
             include: includes,
-            out: a.options.outfile
+            out: a.options.outfile,
+            shim: require(configfile).shim
         };
         requirejs.optimize(config, function (build_response) {
             logger.end(a.options.outfile);


### PR DESCRIPTION
Issue: the compile command currently doesn't include shim config the project is using, so optimized output breaks

Solution: include shim config from jam/require.config.js in the optimize call