### PR TITLE
Always call the completeAuth callback with a parsed url

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -101,7 +101,7 @@ exports.completeAuth = function (url, force, callback) {
         // no auth info, but auth required
         return exports.getAuth(url, callback);
     }
-    callback(null, url);
+    callback(null, urlFormat(parsed));
 };
 
 


### PR DESCRIPTION
If completeAuth is called with an authenticated url object then it calls the callback with the original unparsed url.

The following url object will result in the callback being called with the same url object.

```
{
    url: "http://USERNAME:PASSWORD@myjamjs.com//jam",
    search: "http://USERNAME:PASSWORD@myjamjs.com//jam/_search"
}
```

If the url requires authentication then it calls the callback with an already parsed url.
The following url object will result in the callback being called with the url 'http://myjamjs.com//jam'

```
{
    url: "http://myjamjs.com//jam",
    search: "http://USERNAME:PASSWORD@myjamjs.com//jam/_search"
}
```

In the case of the publish command this results in calling doPublish with a url object when it expects a string.
