### PR TITLE
Absolute script uri's

### DIFF
--- a/lib/commands/rebuild.js
+++ b/lib/commands/rebuild.js
@@ -87,7 +87,8 @@ exports.rebuild = function (settings, cfg, opt, callback) {
             return logger.error(err);
         }
         // TODO: write package.json if --save option provided
-        project.updateRequireConfig(opt.target_dir, opt.baseurl, opt.config, callback);
+        var locationBase = (cfg.jam && cfg.jam.locationBase) ? cfg.jam.locationBase : '';
+        project.updateRequireConfig(opt.target_dir, opt.baseurl, opt.config, locationBase, callback);
     });
 };
 

--- a/lib/project.js
+++ b/lib/project.js
@@ -145,7 +145,7 @@ exports.getAllPackages = function (dir, callback) {
     });
 };
 
-exports.updateRequireConfig = function (package_dir, baseurl, /*opt*/rcfg, callback) {
+exports.updateRequireConfig = function (package_dir, baseurl, /*opt*/rcfg, location_base, callback) {
 
     rcfg = rcfg || {};
 
@@ -158,6 +158,7 @@ exports.updateRequireConfig = function (package_dir, baseurl, /*opt*/rcfg, callb
     var shims = {};
 
     var basedir = baseurl ? path.relative(baseurl, package_dir): package_dir;
+    basedir = (location_base) ? location_base + '/' + basedir : basedir;
     var dir = basedir.split(path.sep).map(encodeURIComponent).join('/');
 
     exports.getAllPackages(package_dir, function (err, pkgs) {


### PR DESCRIPTION
This is my first time working with Jam, and I am fairly new with require, so sorry if this is a totally noob problem/non-problem.

I was hoping to roll Jam it into an Express.js app I am working on.  Maybe there is something for this that I am totally missing, but I saw #84 and think this would solve both problems.  My `package.json` looked like this:

```
"jam": {
    "packageDir": "public/js/lib",
    "baseUrl": "public/js",
    "dependencies": {
        "jquery": "1.8.3"
    }
}
```

After building the require config files, this is what they looked like:

```
require.config({
    "packages": [
        {   
            "name": "jquery",
            "location": "lib/jquery",
            "main": "dist/jquery.js"
        }   
    ],  
    "shim": {}
});
```

Notice the `"location" : "lib/jquery"`.  What I wanted this to be was `/js/lib/jquery`.

This change adds an option `locationBase` (might not be the best name...), which is then appended to the location, resulting in:

```
// package.json
"jam": {
    "packageDir": "public/js/lib",
    "baseUrl": "public/js",
    "locationBase": "/js",
    "dependencies": {
        "jquery": "1.8.3"
    }
}

// require.js
require.config({
    "packages": [
        {   
            "name": "jquery",
            "location": "/js/lib/jquery",
            "main": "dist/jquery.js"
        }   
    ],  
    "shim": {}
});
```

I setup the tests and ran them after making the change and only got one failure:

![jam-tests](https://f.cloud.github.com/assets/1027776/29374/562a499a-4d6a-11e2-973d-6d21f161c6bf.png)

I dont think that has anything to do with the changes, but let me know if I am wrong...

Anyway, good work on the package manager!!
