### PR TITLE
Upgrade Require.js to latest 2.1.2 -- Fixes #115

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jamjs",
-    "version": "0.2.12",
+    "version": "0.2.13",
     "description": "",
     "maintainers": [
         {"name": "Caolan McMahon", "web": "https://github.com/caolan"}
@@ -21,7 +21,7 @@
         "minimatch": "~0.2.5",
         "request": "~2.9.202",
         "almond": "0.1.1",
-        "requirejs": "2.0.6"
+        "requirejs": "2.1.2"
     },
     "devDependencies": {
         "nodeunit": "0.7.4"


### PR DESCRIPTION
Ran unit and functional tests, all are passing. Some non-updated packages may fail in some cases, but I think many more are beginning to fail because they only support 2.1.x now.
