### PR TITLE
Remove decodeURIComponent() call on this.instance.auth because ...

### DIFF
--- a/lib/couchdb.js
+++ b/lib/couchdb.js
@@ -170,9 +170,7 @@ CouchDB.prototype.client = function (method, path, data, callback) {
     }
 
     if (this.instance.auth) {
-        var enc = new Buffer(
-            decodeURIComponent(this.instance.auth)
-        ).toString('base64');
+        var enc = new Buffer(this.instance.auth).toString('base64');
         headers.Authorization = "Basic " + enc;
     }
 


### PR DESCRIPTION
...this.instance.auth was never encoded, and my crazy password caused decodeURIComponent to throw an error:

> Error: URIError: URI malformed
>     at decodeURIComponent (native)
>     at CouchDB.client (/usr/lib/node_modules/jamjs/lib/couchdb.js:174:13)
>     at CouchDB.session (/usr/lib/node_modules/jamjs/lib/couchdb.js:447:10)
>     at exports.doPublish (/usr/lib/node_modules/jamjs/lib/commands/publish.js:62:10)
>     at Object.exports.catchAuthError (/usr/lib/node_modules/jamjs/lib/utils.js:109:8)
>     at exports.publish (/usr/lib/node_modules/jamjs/lib/commands/publish.js:47:15)
>     at exports.getAuth (/usr/lib/node_modules/jamjs/lib/utils.js:171:17)
>     at ReadStream.data (/usr/lib/node_modules/jamjs/node_modules/prompt/lib/prompt.js:610:18)
>     at ReadStream.EventEmitter.emit (events.js:96:17)
>     at TTY.onread (net.js:392:31)
> Failed
