### PR TITLE
Fixed link to iriscouch.com in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Jam includes two test suites, unit tests (in `test/unit`) and integration
 tests (in `test/integration`). The unit tests are easy to run by running the
 `test/unit.sh` script, or `test\unit.bat` on Windows. The integration tests
 first require you to set up a CouchDB instance to test against (you can get
-a free account at [IrisCouch](iriscouch.com] if you don't want to install
+a free account at [IrisCouch](http://www.iriscouch.com/) if you don't want to install
 CouchDB). You then need to set the JAM\_TEST\_DB environment variable to
 point to a CouchDB database URL for testing:
 


### PR DESCRIPTION
The link had a slightly wrong markdown syntax, and was missing the http:// so it acted like a relative link. (Also, their website apparently doesn't work without "www.", so I added that and emailed them.)
