### PR TITLE
Fix "TypeError: Arguments to path.resolve must be strings" error when using node v0.10.0.

### DIFF
--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -130,7 +130,12 @@ exports.extendOptions = function (proj_dir, settings, cfg, opt) {
             opt.baseurl = path.resolve(proj_dir, cfg.jam.baseUrl);
         }
         else {
-            opt.baseurl = path.resolve(proj_dir, settings.baseUrl);
+            if (settings.baseUrl) {
+                opt.baseurl = path.resolve(proj_dir, settings.baseUrl);
+            }
+            else {
+                opt.baseurl = proj_dir;
+            }
         }
     }
     return opt;


### PR DESCRIPTION
Using `jam install` with node v0.10.0 causes the following error:

```
Error: TypeError: Arguments to path.resolve must be strings
    at Object.exports.resolve (path.js:313:15)
    at Object.exports.extendOptions (/usr/local/share/npm/lib/node_modules/jamjs/lib/commands/install.js:133:32)
    at /usr/local/share/npm/lib/node_modules/jamjs/lib/commands/install.js:97:23
    at /usr/local/share/npm/lib/node_modules/jamjs/lib/commands/install.js:301:13
    at /usr/local/share/npm/lib/node_modules/jamjs/node_modules/async/lib/async.js:677:28
    at /usr/local/share/npm/lib/node_modules/jamjs/lib/project.js:74:20
    at /usr/local/share/npm/lib/node_modules/jamjs/lib/project.js:47:20
    at Object.cb [as oncomplete] (fs.js:168:19)
```

This is fixed by falling back to the project directory if `settings.baseUrl` is undefined.
