### PR TITLE
private repository server search issues

### DIFF
--- a/lib/couchdb.js
+++ b/lib/couchdb.js
@@ -141,7 +141,12 @@ CouchDB.prototype.deleteDB = function (callback) {
 
 CouchDB.prototype.client = function (method, path, data, callback) {
     var pathname = this.instance.pathname;
-    path = (pathname ? pathname + '/' + path : '/' + path);
+    if (pathname && !path) {
+        path = pathname;
+    }
+    else {
+        path = (pathname ? pathname + '/' + path : '/' + path);
+    }
     path = path.replace(/^\/\/+/, '/');
 
     var headers = {


### PR DESCRIPTION
The problem: we are using a private repository with couchdb-lucene. The search on our couchDB works fine if we call
http://host:5984/_fti/local/repository/_design/jam-packages/packages?q=hello
Jam search appends a slash at the end generating the following url:
http://host:5984/_fti/local/repository/_design/jam-packages/packages/?q=hello
Which does not work (we get 400: Bad Request).

We managed to solve that issue by not appending a slash if path is empty (see diff).

Jam 2.6
CouchDB 1.3.0
Couchdb-lucene-0.10.0

Thanks!
