### PR TITLE
fixed missing user-agent header for github api v3

### DIFF
--- a/lib/github.js
+++ b/lib/github.js
@@ -35,7 +35,8 @@ exports.repos.getArchiveLink = function (user, repo, format, ref, callback) {
         json: true,
         followRedirect: false,
         headers: {
-            'Accept': 'application/vnd.github.beta+json'
+            'Accept': 'application/vnd.github.beta+json',
+            'User-Agent': 'Jam'
         },
         url: url.resolve(
             exports.GITHUB_URL,
@@ -64,7 +65,8 @@ exports.repos.search = function (q, callback) {
     var req = {
         json: true,
         headers: {
-            'Accept': 'application/vnd.github.beta+json'
+            'Accept': 'application/vnd.github.beta+json',
+            'User-Agent': 'Jam'
         },
         url: url.resolve(
             exports.GITHUB_URL,


### PR DESCRIPTION
Currently `jam install gh:user/repo` is giving `Error: Failed to get archive link` due to this - http://developer.github.com/v3/#user-agent-required
