### PR TITLE
Fix bug where node_modules are loaded using fs rather than require

### DIFF
--- a/lib/project.js
+++ b/lib/project.js
@@ -119,16 +119,15 @@ exports.writeMeta = function (package_dir, data, callback) {
 
 // adds RequireJS to project directory
 exports.makeRequireJS = function (package_dir, config, callback) {
-    var source = path.resolve(__dirname,'../node_modules/requirejs/require.js');
-    var dest = path.resolve(package_dir, 'require.js');
-    logger.info('updating', path.relative(process.cwd(), dest));
-    fs.readFile(source, function (err, content) {
-        if (err) {
-            return callback(err);
-        }
+    try {
+        var dest = path.resolve(package_dir, 'require.js');
+        logger.info('updating', path.relative(process.cwd(), dest));
+        var content = require('requirejs/require.js');
         var src = content.toString() + '\n' + config;
         fs.writeFile(dest, src, callback);
-    });
+    } catch (err) {
+        return callback(err);
+    }
 };
 
 exports.getAllPackages = function (dir, callback) {
@@ -223,7 +222,7 @@ exports.updateRequireConfig = function (package_dir, baseurl, /*opt*/rcfg, callb
                 version: version,
                 shim: shims
             }
-            
+
             // now bring in other require.config.js options to make available
             // earlier versions had variable substitution that breaks on r.js compilation
             // now there is duplication - however, the original jam has been left untouched.
@@ -231,7 +230,7 @@ exports.updateRequireConfig = function (package_dir, baseurl, /*opt*/rcfg, callb
             cfg.packages = _.union(rcfg.packages || [], packages);
             cfg.shim = _.extend({}, rcfg.shim || {}, shims);
             var configStr = JSON.stringify(cfg, null, 4);
-            
+
             var src = 'var jam = ' + JSON.stringify(data, null, 4) + ';\n' +
                 '\n' +
                 'if (typeof require !== "undefined" && require.config) {\n' +
@@ -245,7 +244,7 @@ exports.updateRequireConfig = function (package_dir, baseurl, /*opt*/rcfg, callb
                     'typeof module !== "undefined") {\n' +
                 '    module.exports = jam;\n' +
                 '}';
-            
+
             var filename = path.resolve(package_dir, 'require.config.js');
             mkdirp(package_dir, function (err) {
                 if (err) {


### PR DESCRIPTION
When using Jam with NPM v3, node_modules are stored at the top level, not recursively.

As such, `fs.readFile('../node_modules/require/require.js', cb)` should be replaced with the `require` syntax: `require('require/require.js')`.